### PR TITLE
Added sleep to avoid gateway timeout

### DIFF
--- a/controlIntf.py
+++ b/controlIntf.py
@@ -11,6 +11,7 @@ from loggingIntf import logger
 from escholIntf import eschol
 from escholDBIntf import escholDB
 import depositFields
+import time
 
 class repQueries:
 
@@ -158,6 +159,7 @@ class controller:
                 res = self.escholQ.depositItem(self.pub_depInputdict[x])
                 self.log.saveResult(x, res)
                 self.depositCount += 1
+                time.sleep(100)
         print("End: processCurrentBatch")
 
     def createIdIfNeeded(self, pubId):

--- a/escholIntf.py
+++ b/escholIntf.py
@@ -4,7 +4,7 @@ import traceback
 from urllib import request
 from urllib import error
 import json
-
+import time
 ########################################
 #
 # Interfaces with escholarship graphQL 
@@ -25,10 +25,10 @@ class graphClient:
 
     def _send(self, query):
         data = {'query': query}
-        
+        time.sleep(10)
         req = request.Request(self.endpoint, json.dumps(data).encode('utf-8'), self.headers)
         try:
-            response = request.urlopen(req, timeout=180)
+            response = request.urlopen(req, timeout=1800)
             return response.read().decode('utf-8')
         except error.HTTPError as e:
             print(e.read())


### PR DESCRIPTION
Sleep between deposits is working with API timeout problem. The increase in timeout was added for trello item pubd-727 (gateway timeout) and have been in use. 