### PR TITLE
Added check for repeated authors because of pub merging

### DIFF
--- a/depositFields.py
+++ b/depositFields.py
@@ -166,8 +166,14 @@ class authors:
         items = []
         self.outstr = ""
 
+        # in case publication records are merged on Elements side, 
+        # take one set of authors
+        # the author list from query is sorted by order
+        lastorder = -1
         for p in people:
-            items.append(user(p))
+            if p[0] != lastorder:
+                items.append(user(p))
+            lastorder = p[0]
 
         for i in items:
             self.outstr += i.outstr


### PR DESCRIPTION
The fix is for the situation when there are multiple publication records for a specific publication id. I added a check for author order to skip identical authors when building the list for escholarship. Related Trello card is https://trello.com/c/YihqrmAh